### PR TITLE
Upgrade Python to 3.11.13 and update all dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           pip3 install pipenv
       - name: Setup environment and dependencies
         run: |
-          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.5
+          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.13
           pipenv sync --dev
       - name: Create binaries
         run: |
@@ -57,7 +57,7 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
-          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.5
+          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.13
           pipenv sync --dev
       - name: Create binaries
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Setup environment and dependencies
         run: |
           set PYTHON_CONFIGURE_OPTS '--enable-shared'
-          C:\Users\runneradmin\.pyenv\pyenv-win\bin\pyenv install 3.9.5
+          C:\Users\runneradmin\.pyenv\pyenv-win\bin\pyenv install 3.11.13
           pipenv run pip install -r requirements-dev.txt
       - name: Create binaries
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6
+FROM python:3.11
 ADD requirements.txt /
 RUN pip install -r /requirements.txt \
  && rm /requirements.txt \

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM python:3.8.6
+FROM python:3.11
 ADD requirements-dev.txt /
 RUN pip install -r /requirements-dev.txt \
  && rm /requirements-dev.txt \

--- a/Pipfile
+++ b/Pipfile
@@ -6,15 +6,13 @@ name = "pypi"
 [packages]
 "mido" = "*"
 "python-rtmidi" = "*"
-"argparse" = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [dev-packages]
 "flake8" = "*"
 "pylint" = "*"
-"pyinstaller" = ">=5.13.1,<6.0"
+"pyinstaller" = ">=6.16.0"
 "pytest" = "*"
-"macholib" = "*"
-"setuptools" = ">=70.0.0"
+"setuptools" = ">=80.0.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,27 +1,6 @@
 -i https://pypi.python.org/simple
-altgraph==0.17.3
-astroid==2.12.13 ; python_full_version >= '3.7.2'
-attrs==22.1.0 ; python_version >= '3.5'
-dill==0.3.6 ; python_version >= '3.7'
-exceptiongroup==1.0.4 ; python_version < '3.11'
-flake8==6.0.0
-iniconfig==1.1.1
-isort==5.10.1 ; python_version < '4.0' and python_full_version >= '3.6.1'
-lazy-object-proxy==1.8.0 ; python_version >= '3.7'
-macholib==1.16.2
-mccabe==0.7.0 ; python_version >= '3.6'
-packaging==21.3 ; python_version >= '3.6'
-platformdirs==2.5.4 ; python_version >= '3.7'
-pluggy==1.0.0 ; python_version >= '3.6'
-pycodestyle==2.10.0 ; python_version >= '3.6'
-pyflakes==3.0.1 ; python_version >= '3.6'
-pyinstaller==5.6.2
-pyinstaller-hooks-contrib==2022.13 ; python_version >= '3.7'
-pylint==2.15.7
-pyparsing==3.0.9 ; python_full_version >= '3.6.8'
-pytest==7.2.0
-setuptools==65.6.3 ; python_version >= '3.7'
-tomli==2.0.1 ; python_version < '3.11'
-tomlkit==0.11.6 ; python_version >= '3.6'
-typing-extensions==4.4.0 ; python_version < '3.10'
-wrapt==1.14.1 ; python_version < '3.11'
+flake8==7.3.0
+pylint==4.0.2
+pytest==8.4.2
+pyinstaller==6.16.0
+setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -i https://pypi.python.org/simple
-argparse==1.4.0
-mido==1.2.10
-python-rtmidi==1.4.9
+mido==1.3.2
+python-rtmidi==1.5.8


### PR DESCRIPTION
- Upgraded Python from 3.9.5 to 3.11.13 (EOL: Oct 2027)
- Updated production dependencies:
  * mido: 1.2.10 → 1.3.2
  * python-rtmidi: 1.4.9 → 1.5.8
  * Removed argparse (now in stdlib)
- Updated development dependencies:
  * flake8: 6.0.0 → 7.3.0
  * pylint: 2.15.7 → 4.0.2
  * pytest: 7.2.0 → 8.4.2
  * pyinstaller: 5.6.2 → 6.16.0
  * setuptools: 65.6.3 → 80.9.0
  * Removed conditional dependencies (exceptiongroup, tomli, typing-extensions, wrapt) no longer needed for Python 3.11+
- Updated Dockerfiles to use python:3.11 base image
- Updated CI/CD workflows to use Python 3.11.13

This upgrade ensures better security, performance, and extended support until October 2027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)