### PR TITLE
fix(ci): use brew to install pipenv on macos-26 runner 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 # Build on the oldest supported images, so we have broader compatibility
 jobs:
   macOS:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Install brew packages
         run: |
-          brew install pyenv
-          pip3 install pipenv
+          brew install pyenv pipenv
       - name: Setup environment and dependencies
         run: |
           env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.13

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 # Build on the oldest supported images, so we have broader compatibility
 jobs:
   macOS:
-    runs-on: macos-13
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 # Build on the oldest supported images, so we have broader compatibility
 jobs:
   macOS:
-    runs-on: macos-26
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Upgrades the macOS CI runner from macos-13 to macos-26 and fixes the resulting pip failure caused by PEP 668:
newer macOS runners use a Homebrew-managed Python that blocks system-wide pip3 install. 
Replaces `pip3 install pipenv` with `brew install pipenv` to avoid the externally-managed-environment error. 