### PR TITLE
Upgrade Python to 3.14.3 and update all dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           brew install pyenv pipenv
       - name: Setup environment and dependencies
         run: |
-          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.13
+          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.14.3
           pipenv sync --dev
       - name: Create binaries
         run: |
@@ -56,7 +56,7 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
-          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.13
+          env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.14.3
           pipenv sync --dev
       - name: Create binaries
         run: |
@@ -86,7 +86,7 @@ jobs:
       - name: Setup environment and dependencies
         run: |
           set PYTHON_CONFIGURE_OPTS '--enable-shared'
-          C:\Users\runneradmin\.pyenv\pyenv-win\bin\pyenv install 3.11.13
+          C:\Users\runneradmin\.pyenv\pyenv-win\bin\pyenv install 3.14.3
           pipenv run pip install -r requirements-dev.txt
       - name: Create binaries
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.14
 ADD requirements.txt /
 RUN pip install -r /requirements.txt \
  && rm /requirements.txt \

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.14
 ADD requirements-dev.txt /
 RUN pip install -r /requirements-dev.txt \
  && rm /requirements-dev.txt \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
 	flake8 *py
-	python3.8 -m pytest
+	python3.14 -m pytest

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ name = "pypi"
 "python-rtmidi" = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.14"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddbd4a35a0aa5da0617a9d4aa999e00c0ce68c97836d47a1e02698951633e0e6"
+            "sha256": "f75b0e71f9accd3d03b96cfc983507784998b8bb203f17ee5c1186c63dfccb0c"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11"
+            "python_version": "3.14"
         },
         "sources": [
             {


### PR DESCRIPTION
## Summary
- Bumps Python from 3.11.13 to 3.14.3 across all configurations
- Updates Pipfile, Dockerfiles, Makefile, CI workflow (all 3 platforms), and regenerates Pipfile.lock
- Also fixes a stale `python3.8` reference in Makefile

## Test plan
- [ ] CI passes on macOS, Linux, and Windows jobs
- [ ] Binaries build successfully with PyInstaller